### PR TITLE
Move to native BigInt

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
     "token-amount": "link:.."
   },
   "devDependencies": {
+    "@babel/core": "^7.12.3",
     "@types/bn.js": "^4.11.6",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",

--- a/example/package.json
+++ b/example/package.json
@@ -10,11 +10,15 @@
     "token-amount": "link:.."
   },
   "devDependencies": {
-    "@babel/core": "^7.12.3",
     "@types/bn.js": "^4.11.6",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "parcel": "^1.12.3",
     "typescript": "^3.4.5"
-  }
+  },
+  "browserslist": [
+    "> 2%",
+    "not dead",
+    "not ie > 0"
+  ]
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "target": "es2015",
+    "target": "es2016",
     "module": "commonjs",
     "jsx": "react",
     "moduleResolution": "node",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -14,7 +14,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
   integrity sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==
 
-"@babel/core@^7.12.3", "@babel/core@^7.4.4":
+"@babel/core@^7.4.4":
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
   integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
@@ -1440,9 +1440,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001157:
-  version "1.0.30001157"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz#2d11aaeb239b340bc1aa730eca18a37fdb07a9ab"
-  integrity sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==
+  version "1.0.30001158"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz#fce86d321369603c2bc855ee0e901a7f49f8310b"
+  integrity sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1877,9 +1877,9 @@ cssnano@^4.0.0, cssnano@^4.1.10:
     postcss "^7.0.0"
 
 csso@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.1.0.tgz#1d31193efa99b87aa6bad6c0cef155e543d09e8b"
-  integrity sha512-h+6w/W1WqXaJA4tb1dk7r5tVbOm97MsKxzwnvOR04UQ6GILroryjMWu3pmCCtL2mLaEStQ0fZgeGiy99mo7iyg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-4.1.1.tgz#e0cb02d6eb3af1df719222048e4359efd662af13"
+  integrity sha512-Rvq+e1e0TFB8E8X+8MQjHSY6vtol45s5gxtLI/018UsAn2IBMmwNEZRM/h+HVnAJRHjasLIKKUO3uvoMM28LvA==
   dependencies:
     css-tree "^1.0.0"
 
@@ -2024,15 +2024,6 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-serializer@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.1.0.tgz#5f7c828f1bfc44887dc2a315ab5c45691d544b58"
-  integrity sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    entities "^2.0.0"
-
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -2062,13 +2053,6 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domhandler@^3.0.0, domhandler@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
-  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
-  dependencies:
-    domelementtype "^2.0.1"
-
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -2076,15 +2060,6 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-domutils@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.2.tgz#7ee5be261944e1ad487d9aa0616720010123922b"
-  integrity sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==
-  dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.0.1"
-    domhandler "^3.3.0"
 
 dot-prop@^5.2.0:
   version "5.3.0"
@@ -2124,9 +2099,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.591:
-  version "1.3.595"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.595.tgz#e8a9e7c6919963419f892ea981d7b3438ccb834d"
-  integrity sha512-JpaBIhdBkF9FLG7x06ONfe0f5bxPrxRcq0X+Sc8vsCt+OPWIzxOD+qM71NEHLGbDfN9Q6hbtHRv4/dnvcOxo6g==
+  version "1.3.597"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.597.tgz#0d30fd4c0f5437149c28a6044c4e119357ae56aa"
+  integrity sha512-VJI21MucKaqyFw0oe3j9BIg+nDF4MHzUZAmUwZzrxho+s8zPCD13Fds07Rgu+MTtAadO4tYTKFdAUksKYUyIJw==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -2668,17 +2643,19 @@ html-tags@^1.0.0:
   integrity sha1-x43mW1Zjqll5id0rerSSANfk25g=
 
 htmlnano@^0.2.2:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-0.2.7.tgz#8d116750c15571687edf56069a7819d41925bdcb"
-  integrity sha512-ozbK3npguK3MTn77WCKngBtCDhc94fmEptPQsn+dO+uIWoEghIMKsjzCMnDJuu403M01ePg9GA5MpXhRBQ3PVg==
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-0.2.8.tgz#d9c22daa18c8ea7675a0bf07cc904793ccaeb56f"
+  integrity sha512-q5gbo4SIDAE5sfJ5V0UD6uu+n1dcO/Mpr0B6SlDlJBoV7xKPne4uG4UwrT8vUWjdjIPJl95TY8EDuEbBW2TG0A==
   dependencies:
     cssnano "^4.1.10"
     posthtml "^0.13.4"
-    posthtml-render "^1.2.2"
+    posthtml-render "^1.3.0"
     purgecss "^2.3.0"
     relateurl "^0.2.7"
+    srcset "^3.0.0"
     svgo "^1.3.2"
     terser "^4.8.0"
+    timsort "^0.3.0"
     uncss "^0.17.3"
 
 htmlparser2@^3.9.2:
@@ -2692,16 +2669,6 @@ htmlparser2@^3.9.2:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
-
-htmlparser2@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.1.tgz#7daa6fc3e35d6107ac95a4fc08781f091664f6e7"
-  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.3.0"
-    domutils "^2.4.2"
-    entities "^2.0.0"
 
 http-errors@~1.7.2:
   version "1.7.3"
@@ -3426,9 +3393,9 @@ node-libs-browser@^2.0.0:
     vm-browserify "^1.0.1"
 
 node-releases@^1.1.66:
-  version "1.1.66"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz#609bd0dc069381015cd982300bae51ab4f1b1814"
-  integrity sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==
+  version "1.1.67"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
+  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -4117,13 +4084,13 @@ posthtml-parser@^0.4.0, posthtml-parser@^0.4.1:
     htmlparser2 "^3.9.2"
 
 posthtml-parser@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.5.2.tgz#09fe45ebc6730cae4993f860c26596171ccd9604"
-  integrity sha512-rwRA0TyUTivQN6NAG8CLhi8KEdqjWQMZSAJQedxkuH1c8/hme99WDVOW+z8Ony+YLmoaH0sJRUk6RCWVFQ6Rkw==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.5.3.tgz#e95b92e57d98da50b443e116fcee39466cd9012e"
+  integrity sha512-uHosRn0y+1wbnlYKrqMjBPoo/kK5LPYImLtiETszNFYfFwAD3cQdD1R2E13Mh5icBxkHj+yKtlIHozCsmVWD/Q==
   dependencies:
-    htmlparser2 "^5.0.1"
+    htmlparser2 "^3.9.2"
 
-posthtml-render@^1.1.3, posthtml-render@^1.1.5, posthtml-render@^1.2.2, posthtml-render@^1.2.3:
+posthtml-render@^1.1.3, posthtml-render@^1.1.5, posthtml-render@^1.2.3, posthtml-render@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.3.0.tgz#118d3e5738b862d323055040068d610d2108bd39"
   integrity sha512-km+kuwydlc2lnx4FnHmTwejGtgmfjBT2fOqu9mDTJUoNecwwMnx4soRxngfJ1Qvpa/OLu1YIqZ+/0OiJDOnCzg==
@@ -4711,6 +4678,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+srcset@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-3.0.0.tgz#8afd8b971362dfc129ae9c1a99b3897301ce6441"
+  integrity sha512-D59vF08Qzu/C4GAOXVgMTLfgryt5fyWo93FZyhEWANo0PokFz/iWdDe13mX3O5TRf6l8vMTqckAfR4zPiaH0yQ==
 
 sshpk@^1.7.0:
   version "1.16.1"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -14,7 +14,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
   integrity sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==
 
-"@babel/core@^7.4.4":
+"@babel/core@^7.12.3", "@babel/core@^7.4.4":
   version "7.12.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
   integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
@@ -3045,11 +3045,6 @@ js-yaml@^3.10.0, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-jsbi@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.1.4.tgz#9654dd02207a66a4911b4e4bb74265bc2cbc9dd0"
-  integrity sha512-52QRRFSsi9impURE8ZUbzAMCLjPm4THO7H2fcuIvaaeFTbSysvkodbQQXIVsNgq/ypDbq6dJiuGKL0vZ/i9hUg==
 
 jsbn@~0.1.0:
   version "0.1.1"

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
       "limit": "10 KB"
     }
   ],
-  "dependencies": {
-    "jsbi": "^3.1.4"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.6.0",
     "@typescript-eslint/eslint-plugin": "^4.3.0",

--- a/src/TokenAmount.ts
+++ b/src/TokenAmount.ts
@@ -1,21 +1,20 @@
-import JSBI from 'jsbi'
 import { convertAmount } from './convert'
 import { formatTokenAmount } from './format'
 import { BigIntish, ExportData, Options, Rate } from './types'
 
 export default class TokenAmount {
-  #decimals: JSBI
-  #value: JSBI
+  #decimals: bigint
+  #value: bigint
   #symbol: string
 
   constructor(value: BigIntish, decimals: BigIntish, { symbol = '' } = {}) {
-    this.#decimals = JSBI.BigInt(String(decimals))
-    this.#value = JSBI.BigInt(String(value))
+    this.#decimals = BigInt(String(decimals))
+    this.#value = BigInt(String(value))
     this.#symbol = symbol
   }
 
   get decimals(): number {
-    return JSBI.toNumber(this.#decimals)
+    return Number(this.#decimals)
   }
 
   get symbol(): string {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,9 +1,8 @@
-import JSBI from 'jsbi'
 import { divideRoundBigInt } from './math'
 import { BigIntish } from './types'
 
 // Cache 10 since we are using it a lot.
-const _10 = JSBI.BigInt(10)
+const _10 = BigInt(10)
 
 /**
  * Converts an amount. The conversion rate is expressed as the amount of the output token
@@ -28,9 +27,9 @@ export function convertAmount(
   convertRate: string | number,
   targetDecimals: BigIntish
 ): string {
-  const parsedAmount = JSBI.BigInt(String(amount))
-  const parsedDecimals = JSBI.BigInt(String(decimals))
-  const parsedTargetDecimals = JSBI.BigInt(String(targetDecimals))
+  const parsedAmount = BigInt(String(amount))
+  const parsedDecimals = BigInt(String(decimals))
+  const parsedTargetDecimals = BigInt(String(targetDecimals))
 
   const [rateWhole = '', rateDec = ''] = String(convertRate).split('.')
 
@@ -38,20 +37,14 @@ export function convertAmount(
   const parsedRateDec = rateDec.replace(/0*$/, '')
 
   // Construct the final rate, and remove any leading zeros
-  const rate = JSBI.BigInt(`${rateWhole}${parsedRateDec}`.replace(/^0*/, ''))
+  const rate = BigInt(`${rateWhole}${parsedRateDec}`.replace(/^0*/, ''))
 
-  const ratePrecision = JSBI.BigInt(parsedRateDec.length)
-  const scaledRate = JSBI.multiply(
-    rate,
-    JSBI.exponentiate(_10, parsedTargetDecimals)
-  )
+  const ratePrecision = BigInt(parsedRateDec.length)
+  const scaledRate = rate * _10 ** parsedTargetDecimals
 
   const convertedAmount = divideRoundBigInt(
-    divideRoundBigInt(
-      JSBI.multiply(parsedAmount, scaledRate),
-      JSBI.exponentiate(_10, ratePrecision)
-    ),
-    JSBI.exponentiate(_10, parsedDecimals)
+    divideRoundBigInt(parsedAmount * scaledRate, _10 ** ratePrecision),
+    _10 ** parsedDecimals
   )
 
   return String(convertedAmount)

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,3 @@
-import JSBI from 'jsbi'
 import { NO_BREAK_SPACE } from './characters'
 import { divideRoundBigInt } from './math'
 import { BigIntish, Options } from './types'
@@ -47,50 +46,42 @@ export function formatTokenAmount(
     displaySign = false,
   } = options
 
-  let parsedAmount = JSBI.BigInt(String(amount))
-  const parsedDecimals = JSBI.BigInt(String(decimals))
-  let parsedDigits = JSBI.BigInt(String(digits))
+  let parsedAmount = BigInt(String(amount))
+  const parsedDecimals = BigInt(String(decimals))
+  let parsedDigits = BigInt(String(digits))
 
-  const _0 = JSBI.BigInt(0)
-  const _10 = JSBI.BigInt(10)
+  const _0 = BigInt(0)
+  const _10 = BigInt(10)
 
-  if (JSBI.lessThan(parsedDecimals, _0)) {
+  if (parsedDecimals < _0) {
     throw new Error('formatTokenAmount(): decimals cannot be negative')
   }
 
-  if (JSBI.lessThan(parsedDigits, _0)) {
+  if (parsedDigits < _0) {
     throw new Error('formatTokenAmount(): digits cannot be negative')
   }
 
-  if (JSBI.lessThan(parsedDecimals, parsedDigits)) {
+  if (parsedDecimals < parsedDigits) {
     parsedDigits = parsedDecimals
   }
 
-  const negative = JSBI.lessThan(parsedAmount, _0)
+  const negative = parsedAmount < _0
 
   if (negative) {
-    parsedAmount = JSBI.unaryMinus(parsedAmount)
+    parsedAmount = -parsedAmount
   }
 
-  const amountConverted = JSBI.equal(parsedDecimals, _0)
-    ? parsedAmount
-    : JSBI.BigInt(
-        divideRoundBigInt(
-          parsedAmount,
-          JSBI.exponentiate(_10, JSBI.subtract(parsedDecimals, parsedDigits))
-        )
-      )
+  const amountConverted =
+    parsedDecimals === _0
+      ? parsedAmount
+      : divideRoundBigInt(parsedAmount, _10 ** (parsedDecimals - parsedDigits))
 
-  const leftPart = JSBI.divide(
-    amountConverted,
-    JSBI.exponentiate(_10, parsedDigits)
-  )
+  const leftPart = amountConverted / _10 ** parsedDigits
+
   const processedLeftPart = commify ? formatNumber(leftPart) : leftPart
 
-  const rightPart = String(
-    JSBI.remainder(amountConverted, JSBI.exponentiate(_10, parsedDigits))
-  )
-    .padStart(Number(parsedDigits), '0')
+  const rightPart = String(amountConverted % _10 ** parsedDigits)
+    .padStart(parseInt(String(parsedDigits)), '0')
     .replace(/0+$/, '')
 
   return [

--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -4,7 +4,7 @@ import { divideRoundBigInt } from './math'
 
 describe('divideRoundBigInt()', () => {
   test('should round the result', () => {
-    expect(divideRoundBigInt(BigInt('479238'), BigInt('10'))).toEqual('47924')
-    expect(divideRoundBigInt(BigInt('479238'), BigInt('5'))).toEqual('95848')
+    expect(divideRoundBigInt(BigInt('479238'), BigInt('10'))).toEqual(47924n)
+    expect(divideRoundBigInt(BigInt('479238'), BigInt('5'))).toEqual(95848n)
   })
 })

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,10 +1,18 @@
+import { BigIntish } from './types'
+
 /**
  * Divide and round two big integers.
  *
- * @param {bigint} dividend Integer to be divided + rounded
- * @param {bigint} divisor  Divisor
- * @returns {bigint}
+ * @param {BigInt|string|number} dividend Integer to be divided + rounded
+ * @param {BigInt|string|number} divisor  Divisor
+ * @returns {BigInt}
  */
-export function divideRoundBigInt(dividend: bigint, divisor: bigint): bigint {
-  return (dividend + divisor / BigInt(2)) / divisor
+export function divideRoundBigInt(
+  dividend: BigIntish,
+  divisor: BigIntish
+): bigint {
+  const parsedDividend = BigInt(String(dividend))
+  const parsedDivisor = BigInt(String(divisor))
+
+  return (parsedDividend + parsedDivisor / BigInt(2)) / parsedDivisor
 }

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,22 +1,10 @@
-import JSBI from 'jsbi'
-import { BigIntish } from './types'
-
 /**
  * Divide and round two big integers.
  *
- * @param {BigInt|string|number} dividend Integer to be divided + rounded
- * @param {BigInt|string|number} divisor  Divisor
- * @returns {string}
+ * @param {bigint} dividend Integer to be divided + rounded
+ * @param {bigint} divisor  Divisor
+ * @returns {bigint}
  */
-export function divideRoundBigInt(
-  dividend: BigIntish,
-  divisor: BigIntish
-): string {
-  const parsedDividend = JSBI.BigInt(String(dividend))
-  const parsedDivisor = JSBI.BigInt(String(divisor))
-
-  return JSBI.divide(
-    JSBI.add(parsedDividend, JSBI.divide(parsedDivisor, JSBI.BigInt(2))),
-    parsedDivisor
-  ).toString()
+export function divideRoundBigInt(dividend: bigint, divisor: bigint): bigint {
+  return (dividend + divisor / BigInt(2)) / divisor
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5324,11 +5324,6 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsbi@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.1.4.tgz#9654dd02207a66a4911b4e4bb74265bc2cbc9dd0"
-  integrity sha512-52QRRFSsi9impURE8ZUbzAMCLjPm4THO7H2fcuIvaaeFTbSysvkodbQQXIVsNgq/ypDbq6dJiuGKL0vZ/i9hUg==
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/aragon/token-amount/pull/9#issuecomment-726742398)

Closes https://github.com/aragon/token-amount/issues/3

I have some reservations as TS doesn't seem to support downleveling `BigInt`:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#caveats-1
https://github.com/microsoft/TypeScript/issues/28756#issuecomment-443312846

It depends how confident we'd feel moving to native exclusively, the size reduction is very nice though. Alternatively we could polyfill / transpile the syntax with a babel plugin, but i'd question the added complexity over keeping the current `jsbi` in that case.

